### PR TITLE
Add threshold to automatically close downvoted feature requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ Other configuration is via `constants.py`:
 
 All constants must be unique.
 
+### Optional
+These environment variables are optional:
+
+- `FR_APPROVE_THRESHOLD` (default 5) - The minimum score for feature requests to be added to GitHub.
+- `FR_DENY_THRESHOLD` (default -3) - The score for feature requests to be automatically closed if they fall under it.
+
 ## Running the bot
 
 1. Create a [virtual environment](https://docs.python.org/3/library/venv.html): `python3 -m venv venv`.

--- a/lib/reports.py
+++ b/lib/reports.py
@@ -1,3 +1,4 @@
+import os
 import re
 from decimal import Decimal
 
@@ -40,8 +41,10 @@ VERI_KEY = {
 GITHUB_BASE = "https://github.com"
 UPVOTE_REACTION = "\U0001f44d"
 DOWNVOTE_REACTION = "\U0001f44e"
-GITHUB_THRESHOLD = 5  # how many upvotes a feature req needs to be added to GitHub
-CLOSE_THRESHOLD = -3  # how many downvotes a feature req needs to be closed automatically
+# how many upvotes a feature req needs to be added to GitHub
+GITHUB_THRESHOLD = int(os.environ.get("FR_APPROVE_THRESHOLD", 5))
+# how many downvotes a feature req needs to be closed automatically
+CLOSE_THRESHOLD = int(os.environ.get("FR_DENY_THRESHOLD", -3))
 
 # we use 0 for a sentinel value since
 # it's an invalid ID in both Discord and GitHub

--- a/lib/reports.py
+++ b/lib/reports.py
@@ -40,7 +40,8 @@ VERI_KEY = {
 GITHUB_BASE = "https://github.com"
 UPVOTE_REACTION = "\U0001f44d"
 DOWNVOTE_REACTION = "\U0001f44e"
-GITHUB_THRESHOLD = 5
+GITHUB_THRESHOLD = 5  # how many upvotes a feature req needs to be added to GitHub
+CLOSE_THRESHOLD = -3  # how many downvotes a feature req needs to be closed automatically
 
 # we use 0 for a sentinel value since
 # it's an invalid ID in both Discord and GitHub
@@ -368,6 +369,8 @@ class Report:
             await self.notify_subscribers(ctx, f"New downvote by <@{author}>: {msg}")
         if self.upvotes - self.downvotes in (14, 9):
             await self.update_labels()
+        if self.upvotes - self.downvotes <= CLOSE_THRESHOLD:
+            await self.resolve(ctx, f"This report was closed because it fell below a score of {CLOSE_THRESHOLD}.")
 
     async def addnote(self, author, msg, ctx, add_to_github=True):
         attachment = Attachment(author, msg)
@@ -432,7 +435,7 @@ class Report:
 
     async def update(self, ctx):
         msg = await self.get_message(ctx)
-        if msg is None and self.severity >= 0:
+        if msg is None and self.is_open():
             await self.setup_message(ctx.bot)
         else:
             await msg.edit(embed=self.get_embed())


### PR DESCRIPTION
Generally, people only downvote feature requests if it's already implemented or way too specific/feature creepy. The close threshold is for is the total score (i.e. upvotes-downvotes).