### PR TITLE
Label feature requests opened on GitHub correctly

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -31,6 +31,7 @@ BUG_LISTEN_CHANS = [
 # what to label issues opened on given repos as
 REPO_ID_MAP = {
     "avrae/avrae": "AVR",
+    "avrae/avrae:feature": "AFR",
     "avrae/avrae.io": "WEB",
     "avrae/avrae-service": "API",
     "avrae/taine": "TNE"


### PR DESCRIPTION
Taine currently labels feature requests opened on GitHub as AVR, but I've been using AFR to track those. This fixes that.