### PR TITLE
Fix certain changes to a report not committing to DB

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -97,9 +97,9 @@ async def canrepro(ctx, _id, *, msg=''):
     report = Report.from_id(_id)
     await report.canrepro(ctx.message.author.id, msg, ctx)
     report.subscribe(ctx)
+    await report.update(ctx)
     report.commit()
     await ctx.send(f"Ok, I've added a note to `{report.report_id}` - {report.title}.")
-    await report.update(ctx)
 
 
 @bot.command(aliases=['up'])
@@ -108,9 +108,9 @@ async def upvote(ctx, _id, *, msg=''):
     report = Report.from_id(_id)
     await report.upvote(ctx.message.author.id, msg, ctx)
     report.subscribe(ctx)
+    await report.update(ctx)
     report.commit()
     await ctx.send(f"Ok, I've added a note to `{report.report_id}` - {report.title}.")
-    await report.update(ctx)
 
 
 @bot.command(aliases=['cnr'])
@@ -119,9 +119,9 @@ async def cannotrepro(ctx, _id, *, msg=''):
     report = Report.from_id(_id)
     await report.cannotrepro(ctx.message.author.id, msg, ctx)
     report.subscribe(ctx)
+    await report.update(ctx)
     report.commit()
     await ctx.send(f"Ok, I've added a note to `{report.report_id}` - {report.title}.")
-    await report.update(ctx)
 
 
 @bot.command(aliases=['down'])
@@ -130,9 +130,9 @@ async def downvote(ctx, _id, *, msg=''):
     report = Report.from_id(_id)
     await report.downvote(ctx.message.author.id, msg, ctx)
     report.subscribe(ctx)
+    await report.update(ctx)
     report.commit()
     await ctx.send(f"Ok, I've added a note to `{report.report_id}` - {report.title}.")
-    await report.update(ctx)
 
 
 @bot.command()
@@ -141,9 +141,9 @@ async def note(ctx, _id, *, msg=''):
     report = Report.from_id(_id)
     await report.addnote(ctx.message.author.id, msg, ctx)
     report.subscribe(ctx)
+    await report.update(ctx)
     report.commit()
     await ctx.send(f"Ok, I've added a note to `{report.report_id}` - {report.title}.")
-    await report.update(ctx)
 
 
 @bot.command(aliases=['sub'])

--- a/cogs/owner.py
+++ b/cogs/owner.py
@@ -67,8 +67,8 @@ class Owner(commands.Cog):
         report.title = name
         if report.github_issue:
             await report.edit_title(f"{report.report_id} {report.title}")
-        report.commit()
         await report.update(ctx)
+        report.commit()
         await ctx.send(f"Renamed {report.report_id} as {report.title}.")
 
     @commands.command(aliases=['pri'])
@@ -84,9 +84,8 @@ class Owner(commands.Cog):
 
         if report.github_issue:
             await report.update_labels()
-
-        report.commit()
         await report.update(ctx)
+        report.commit()
         await ctx.send(f"Changed priority of `{report.report_id}`: {report.title} to P{pri}.")
 
     @commands.group(aliases=['pend'], invoke_without_command=True)
@@ -102,8 +101,8 @@ class Owner(commands.Cog):
                 not_found += 1
                 continue
             report.pend()
-            report.commit()
             await report.update(ctx)
+            report.commit()
         if not not_found:
             await ctx.send(f"Marked {len(reports)} reports as patch pending.")
         else:
@@ -130,8 +129,8 @@ class Owner(commands.Cog):
                 not_found += 1
                 continue
             report.unpend()
-            report.commit()
             await report.update(ctx)
+            report.commit()
         if not not_found:
             await ctx.send(f"Unpended {len(reports)} reports.")
         else:

--- a/web/web.py
+++ b/web/web.py
@@ -132,8 +132,8 @@ class Web(commands.Cog):
                     break
             report.severity = priority
             report.is_bug = FEATURE_LABEL not in label_names
-            report.commit()
             await report.update(ctx)
+            report.commit()
 
     # ===== github: issue_comment event =====
     async def issue_comment_handler(self, data):
@@ -154,8 +154,8 @@ class Web(commands.Cog):
                 return  # oh well
 
             await report.addnote(f"GitHub - {username}", comment['body'], ContextProxy(self.bot), add_to_github=False)
-            report.commit()
             await report.update(ContextProxy(self.bot))
+            report.commit()
 
     def run_app(self, app, *, host='0.0.0.0', port=None, ssl_context=None, backlog=128):
         """Run an app"""


### PR DESCRIPTION
Taine would post multiple messages for old commands because the old message ID would not get committed.