### PR TITLE
Embed image

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -94,9 +94,10 @@ async def on_message(message):
         title = match.group(1).strip(" *.\n")
         report_num = get_next_report_num(identifier)
         report_id = f"{identifier}-{report_num}"
+        attach = "\n" + '\n'.join(f"\n![{attachment.filename}]({attachment.url})" for attachment in message.attachments)
 
         report = await Report.new(message.author.id, report_id, title,
-                                  [Attachment(message.author.id, message.content)], is_bug=is_bug, repo=repo)
+                                  [Attachment(message.author.id, message.content + attach)], is_bug=is_bug, repo=repo)
         if is_bug:
             await report.setup_github(await bot.get_context(message))
 

--- a/bot.py
+++ b/bot.py
@@ -94,8 +94,8 @@ async def on_message(message):
         title = match.group(1).strip(" *.\n")
         report_num = get_next_report_num(identifier)
         report_id = f"{identifier}-{report_num}"
-        attach = "\n" + '\n'.join(f"\n{'!' if item.url.endswith(('.png', '.jpg', '.gif')) else ''}[{item.filename}]({item.url})"
-                                  for item in message.attachments)
+        attach = "\n" + '\n'.join(f"\n{'!' if item.url.lower().endswith(('.png', '.jpg', '.gif')) else ''}"
+                                  f"[{item.filename}]({item.url})" for item in message.attachments)
 
         report = await Report.new(message.author.id, report_id, title,
                                   [Attachment(message.author.id, message.content + attach)], is_bug=is_bug, repo=repo)

--- a/bot.py
+++ b/bot.py
@@ -94,7 +94,8 @@ async def on_message(message):
         title = match.group(1).strip(" *.\n")
         report_num = get_next_report_num(identifier)
         report_id = f"{identifier}-{report_num}"
-        attach = "\n" + '\n'.join(f"\n![{attachment.filename}]({attachment.url})" for attachment in message.attachments)
+        attach = "\n" + '\n'.join(f"\n{'!' if item.url.endswith(('.png', '.jpg', '.gif')) else ''}[{item.filename}]({item.url})"
+                                  for item in message.attachments)
 
         report = await Report.new(message.author.id, report_id, title,
                                   [Attachment(message.author.id, message.content + attach)], is_bug=is_bug, repo=repo)

--- a/bot.py
+++ b/bot.py
@@ -94,10 +94,9 @@ async def on_message(message):
         title = match.group(1).strip(" *.\n")
         report_num = get_next_report_num(identifier)
         report_id = f"{identifier}-{report_num}"
-        attach = "\n" + '\n'.join(f"\n![{attachment.filename}]({attachment.url})" for attachment in message.attachments)
 
         report = await Report.new(message.author.id, report_id, title,
-                                  [Attachment(message.author.id, message.content + attach)], is_bug=is_bug, repo=repo)
+                                  [Attachment(message.author.id, message.content)], is_bug=is_bug, repo=repo)
         if is_bug:
             await report.setup_github(await bot.get_context(message))
 


### PR DESCRIPTION
Embed any attachments that were in the original report. This way they aren't lost, and it prevents us from nagging the original report to append the report with `~note`.