### PR TITLE
AVR-1615 upgrade ddtrace to 3.16.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ PyGithub==1.55
 python-Levenshtein==0.12.2
 
 # Datadog support
-ddtrace==3.16.2
+ddtrace~=3.16.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ PyGithub==1.55
 python-Levenshtein==0.12.2
 
 # Datadog support
-ddtrace~=2.8.2
+ddtrace==3.16.2


### PR DESCRIPTION
### Summary
ddtrace upgraded to 3.16.2 to address the wrapt dependency issue breaking change.
- The `ddtrace` library is not used within the code. It is just used to run on the entrypoint.
- Currently, we're receiving traces and spans on datadog in live.
- Upon local configuration for sending traces, it was confirmed that datadog receive traces correctly with both the old and new version of the library

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [x] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
