### PR TITLE
feat: monster/spell entity-type support in automation submissions

### DIFF
--- a/cogs/reports.py
+++ b/cogs/reports.py
@@ -22,7 +22,11 @@ from lib.reports import Attachment, Report, get_next_report_num
 
 BUG_RE = re.compile(r"\**What is the [Bb]ug\?\**:?\s*(.+?)(\n|$)")
 FEATURE_RE = re.compile(r"\**Feature [Rr]equest\**:?\s*(.+?)(\n|$)")
-AUTOMATION_HEADER_RE = re.compile(r"^\**Automation [Ss]ubmission\**:?\s*$")
+# entity_type defaults to Action when omitted -- a strict superset of the original header,
+# every message that matched before still matches.
+AUTOMATION_HEADER_RE = re.compile(
+    r"^\**Automation Submission\**\s*:?\s*(?P<entity_type>Monster|Spell|Action)?\s*\**\s*$", re.IGNORECASE
+)
 CODE_BLOCK_RE = re.compile(r"^```(?:json|yaml|yml)?\s*\n?|\n?```$", re.IGNORECASE)
 # Strips the trailing "(type=...)" machine-readable detail from each validation error line,
 # leaving the human-readable message. Anchored to end-of-line and greedy so nested parens
@@ -124,10 +128,12 @@ class Reports(commands.Cog):
                 # Check if this is an automation submission (header on first line)
                 lines = message.content.strip().split('\n', 1)
                 first_line = lines[0].strip()
-                
+
                 # If first line doesn't match header, ignore (allow discussion)
-                if not AUTOMATION_HEADER_RE.match(first_line):
+                header_match = AUTOMATION_HEADER_RE.match(first_line)
+                if not header_match:
                     continue
+                entity_type = (header_match.group("entity_type") or "action").lower()
 
                 # Header matched - this is a submission attempt, validate the content
                 static_errors = []
@@ -150,7 +156,7 @@ class Reports(commands.Cog):
                                 break
                             except Exception as e:
                                 static_errors.append(f"Failed to read attachment {attachment.filename}: {e}")
-                    
+
                     # If we had attachments but none were valid
                     if not content and not static_errors:
                         static_errors.append(
@@ -164,6 +170,18 @@ class Reports(commands.Cog):
                         "**Automation Submission**\n"
                         "{\"name\": \"...\", \"automation\": ...}\n"
                         "```\n"
+                        "For a Spell, add a type to the header (same shape as above):\n"
+                        "```\n"
+                        "**Automation Submission: Spell**\n"
+                        "{\"name\": \"...\", \"automation\": ...}\n"
+                        "```\n"
+                        "For a Monster attack, add a type to the header and say which monster it belongs to:\n"
+                        "```\n"
+                        "**Automation Submission: Monster**\n"
+                        "{\"monster\": \"...\", \"name\": \"...\", \"automation\": ...}\n"
+                        "```\n"
+                        "Submit one attack per message -- if a monster has multiple attacks to automate, "
+                        "send a separate message for each.\n"
                         "You can also attach a .json, .yaml, or .txt file."
                     )
                 elif content and not static_errors:
@@ -177,19 +195,41 @@ class Reports(commands.Cog):
                     except yaml.YAMLError as exc:
                         static_errors.append(f"Submission from {content_source} must be valid JSON or YAML. ({exc})")
 
-                # Require both name and automation keys
+                # Require a name and an automation payload; Monster additionally requires a
+                # 'monster' field (which monster this one attack belongs to) and must NOT use
+                # an 'attacks' list -- one attack per message, see the format spec.
                 automation_title = None
+                automation_object = None
+                monster_name = None
                 if data is not None and not static_errors:
+                    if entity_type == "monster":
+                        if "attacks" in data:
+                            static_errors.append(
+                                "Monster submissions don't use an 'attacks' list -- submit one attack "
+                                "per message: `{\"monster\": \"...\", \"name\": \"...\", \"automation\": ...}`."
+                            )
+                        monster_name = data.get("monster")
+                        if not monster_name:
+                            static_errors.append(
+                                "Monster submission must include a 'monster' field naming the monster this attack belongs to."
+                            )
+                    elif "attacks" in data:
+                        static_errors.append(
+                            f"Submission declared as {entity_type.capitalize()} but has an 'attacks' field, "
+                            "which only Monster submissions use -- did you mean to declare this as Monster?"
+                        )
+
                     automation_title = data.get("name")
                     if not automation_title:
                         static_errors.append("Submission must include a 'name' field.")
-                    if not data.get("automation"):
+                    automation_object = data.get("automation")
+                    if not automation_object:
                         static_errors.append("Submission must include an 'automation' field.")
 
                 # Validate the automation against the avrae automation-common schema
                 if data is not None and not static_errors:
                     try:
-                        validation.validate(data["automation"])
+                        validation.validate(automation_object)
                     except ValidationError as exc:
                         formatted = VALIDATION_TYPE_RE.sub("", format_validation_error(exc))
                         static_errors.append(
@@ -213,15 +253,33 @@ class Reports(commands.Cog):
                 
                 if is_valid and not static_errors:
                     thread_id = message.channel.id
-                    file_content = json.dumps([data], indent=2)
+                    if entity_type == "monster":
+                        # Reconstruct the {name, attacks: [...]} shape the rest of the pipeline
+                        # (branch/file routing, merge-by-attack-name, resolve) already expects --
+                        # the submitter only ever sends one attack per message.
+                        file_content = json.dumps(
+                            [{"name": monster_name, "attacks": [{"name": automation_title, "automation": automation_object}]}],
+                            indent=2,
+                        )
+                    else:
+                        file_content = json.dumps([data], indent=2)
 
-                    existing = await Report.find_existing_submission(
+                    existing, existing_entity_type = await Report.find_existing_submission(
                         repo, thread_id, message.author.id, automation_title)
 
                     if existing is not None:
-                        await existing.update_pr(ContextProxy(self.bot), file_content)
-                        await existing.notify_thread(
-                            self.bot, f"↻ Updated your **{automation_title}** submission with the latest version.")
+                        merge_info = await existing.update_pr(ContextProxy(self.bot), file_content, existing_entity_type)
+                        notify_msg = f"↻ Updated your **{automation_title}** submission with the latest version."
+                        if merge_info:
+                            added = [name for name, outcome in merge_info.items() if outcome == "added"]
+                            replaced = [name for name, outcome in merge_info.items() if outcome == "replaced"]
+                            parts = []
+                            if added:
+                                parts.append(f"Added new attack{'s' if len(added) != 1 else ''}: {', '.join(added)}.")
+                            if replaced:
+                                parts.append(f"Updated existing attack{'s' if len(replaced) != 1 else ''}: {', '.join(replaced)}.")
+                            notify_msg = f"↻ Updated your **{automation_title}** submission. " + " ".join(parts)
+                        await existing.notify_thread(self.bot, notify_msg)
                         await message.add_reaction(random.choice(constants.REACTIONS))
                         return
 
@@ -257,7 +315,7 @@ class Reports(commands.Cog):
 
                     # Post in thread, to avoid this remove channel kwarg and uncomment the separate AUTOMATION_TRACKER_CHAN constant and get_channel logic in Report.get_channel
                     await report.setup_message(self.bot, channel=message.channel)
-                    await report.setup_pr(ContextProxy(self.bot), file_content)
+                    await report.setup_pr(ContextProxy(self.bot), file_content, entity_type)
                     report.commit()
 
                     await message.add_reaction(random.choice(constants.REACTIONS))

--- a/constants.py
+++ b/constants.py
@@ -25,8 +25,14 @@ AUTOMATION_LISTEN_CHANS = [
         "id": 1241495694616035379,
         "identifier": "AUT",
         "repo": "avrae/avrae-data-entry",
-        "target_folder": "user-automations/",
         "base_branch": "main",
+        # Per-entity-type staging folder + branch prefix. Folder location is the durable
+        # signal for entity type all the way through to resolution.
+        "entity_config": {
+            "action": {"folder": "user-automations/", "branch_prefix": "user-automation"},
+            "monster": {"folder": "user-monsters/", "branch_prefix": "user-monster"},
+            "spell": {"folder": "user-spells/", "branch_prefix": "user-spell"},
+        },
     }
 ]
 

--- a/lib/dedup.py
+++ b/lib/dedup.py
@@ -22,8 +22,8 @@ def submission_hash(thread_id, user_id, automation_name: str) -> str:
     return digest[:HASH_LEN]
 
 
-def branch_name(thread_id, user_id, automation_name: str) -> str:
-    """Returns the deterministic submission branch name: `user-automation/<slug>-<hash>`."""
+def branch_name(thread_id, user_id, automation_name: str, branch_prefix: str = BRANCH_PREFIX) -> str:
+    """Returns the deterministic submission branch name: `<branch_prefix>/<slug>-<hash>`."""
     slug = slugify(automation_name)
     digest = submission_hash(thread_id, user_id, automation_name)
-    return f"{BRANCH_PREFIX}/{slug}-{digest}"
+    return f"{branch_prefix}/{slug}-{digest}"

--- a/lib/github.py
+++ b/lib/github.py
@@ -174,6 +174,22 @@ class GitHubClient:
 
         return await asyncio.get_event_loop().run_in_executor(None, _)
 
+    async def get_file_content(self, repo, branch, path):
+        """Returns the decoded text content of the file at `path` on `branch`, or None if it
+        doesn't exist."""
+        if not isinstance(repo, Repository):
+            repo = self.get_repo(repo)
+
+        def _():
+            try:
+                return repo.get_contents(path, ref=branch).decoded_content.decode("utf-8")
+            except GithubException as e:
+                if e.status != 404:
+                    raise
+                return None
+
+        return await asyncio.get_event_loop().run_in_executor(None, _)
+
     async def create_draft_pr(self, repo, branch, base, title, body):
         """Opens a draft PR from `branch` into `base`."""
         if not isinstance(repo, Repository):

--- a/lib/reports.py
+++ b/lib/reports.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 import re
@@ -92,6 +93,14 @@ class Attachment:
     @classmethod
     def cnr(cls, author, msg=''):
         return cls(author, msg, -1)
+
+
+def _automation_channel_config(repo):
+    """Returns the AUTOMATION_LISTEN_CHANS entry for `repo`, or raises if none is configured."""
+    for chan in constants.AUTOMATION_LISTEN_CHANS:
+        if chan["repo"] == repo:
+            return chan
+    raise ReportException(f"No automation config found for repo {repo}.")
 
 
 class Report:
@@ -213,16 +222,23 @@ class Report:
 
     @classmethod
     async def find_existing_submission(cls, repo, thread_id, user_id, automation_name):
-        """Returns the Report for an existing open PR for this submission key, or None if there isn't one."""
-        branch = dedup.branch_name(thread_id, user_id, automation_name)
-        pr = await GitHubClient.get_instance().find_open_pr_for_branch(repo, branch)
-        if pr is None:
-            return None
-        try:
-            return cls.from_github(repo, pr.number)
-        except ReportException:
-            log.warning(f"Open PR #{pr.number} on {repo} for branch {branch} has no matching Report")
-            return None
+        """Returns (Report, entity_type) for an existing open PR for this submission key, or
+        (None, None) if there isn't one. Fans out across every configured entity type's branch
+        prefix rather than persisting entity_type on Report -- the branch a submission already
+        lives on is what determines its entity type, not the current message's declared header."""
+        chan = _automation_channel_config(repo)
+        gh = GitHubClient.get_instance()
+        for entity_type, entity_cfg in chan["entity_config"].items():
+            branch = dedup.branch_name(thread_id, user_id, automation_name, branch_prefix=entity_cfg["branch_prefix"])
+            pr = await gh.find_open_pr_for_branch(repo, branch)
+            if pr is None:
+                continue
+            try:
+                return cls.from_github(repo, pr.number), entity_type
+            except ReportException:
+                log.warning(f"Open PR #{pr.number} on {repo} for branch {branch} has no matching Report")
+                return None, None
+        return None, None
 
     def is_open(self):
         return self.severity >= 0
@@ -246,24 +262,26 @@ class Report:
                                                                labels)
         self.github_issue = issue.number
 
-    def _get_automation_config(self):
-        """Returns the (target_folder, base_branch) config for this report's repo."""
-        for chan in constants.AUTOMATION_LISTEN_CHANS:
-            if chan["repo"] == self.repo:
-                return chan["target_folder"], chan["base_branch"]
-        raise ReportException(f"No automation config found for repo {self.repo}.")
+    def _get_automation_config(self, entity_type):
+        """Returns the (target_folder, branch_prefix, base_branch) config for this report's
+        repo and entity type."""
+        chan = _automation_channel_config(self.repo)
+        entity_cfg = chan["entity_config"].get(entity_type)
+        if entity_cfg is None:
+            raise ReportException(f"No automation config found for entity type {entity_type} on repo {self.repo}.")
+        return entity_cfg["folder"], entity_cfg["branch_prefix"], chan["base_branch"]
 
-    def _get_branch_and_path(self):
+    def _get_branch_and_path(self, entity_type):
         """Returns the (branch, file path) for this report's submission branch."""
-        target_folder, _ = self._get_automation_config()
-        branch = dedup.branch_name(self.thread_id, self.reporter, self.automation_name)
+        target_folder, branch_prefix, _ = self._get_automation_config(entity_type)
+        branch = dedup.branch_name(self.thread_id, self.reporter, self.automation_name, branch_prefix=branch_prefix)
         path = target_folder + branch.split("/")[-1] + ".json"
         return branch, path
 
-    async def setup_pr(self, ctx, file_content):
+    async def setup_pr(self, ctx, file_content, entity_type):
         """Opens a draft PR on a new branch for this automation submission."""
-        _, base_branch = self._get_automation_config()
-        branch, path = self._get_branch_and_path()
+        _, _, base_branch = self._get_automation_config(entity_type)
+        branch, path = self._get_branch_and_path(entity_type)
         gh = GitHubClient.get_instance()
         await gh.get_or_create_branch(self.repo, branch, base_branch)
         await gh.create_or_update_file(self.repo, branch, path, file_content,
@@ -273,11 +291,64 @@ class Report:
                                       self.get_github_desc(ctx))
         self.github_issue = pr.number
 
-    async def update_pr(self, ctx, file_content):
-        """Pushes an updated submission file to this report's existing PR branch."""
-        branch, path = self._get_branch_and_path()
-        await GitHubClient.get_instance().create_or_update_file(
+    async def update_pr(self, ctx, file_content, entity_type):
+        """Pushes an updated submission file to this report's existing PR branch. For Monster
+        submissions, merges the new attacks into the existing PR file by attack name instead of
+        replacing it wholesale, so a resubmission targeting one attack doesn't drop the others.
+        Returns a dict of {attack_name: "added"|"replaced"} for Monster updates, or None otherwise."""
+        branch, path = self._get_branch_and_path(entity_type)
+        gh = GitHubClient.get_instance()
+        merge_info = None
+        if entity_type == "monster":
+            file_content, merge_info = await self._merge_monster_attacks(gh, branch, path, file_content)
+        await gh.create_or_update_file(
             self.repo, branch, path, file_content, f"Update user-submitted automation: {self.automation_name}")
+        return merge_info
+
+    async def _merge_monster_attacks(self, gh, branch, path, new_file_content):
+        """Merges the new submission's attacks into the existing PR file's attacks by
+        case-insensitive attack name -- a matching name replaces that attack in place, a new
+        name is appended. Attacks not mentioned in the new submission are left untouched.
+        Returns (merged_file_content, merge_info) where merge_info maps each submitted attack's
+        original-case name to "added" or "replaced", for the resubmission notification."""
+        new_data = json.loads(new_file_content)[0]
+        new_attacks = new_data.get("attacks", [])
+
+        existing_content = await gh.get_file_content(self.repo, branch, path)
+        if existing_content is None:
+            return new_file_content, {a["name"]: "added" for a in new_attacks}
+
+        existing_data = json.loads(existing_content)[0]
+        existing_attacks = existing_data.get("attacks", [])
+        by_lower_name = {a["name"].lower(): a for a in existing_attacks}
+
+        merge_info = {}
+        for attack in new_attacks:
+            key = attack["name"].lower()
+            if key in by_lower_name:
+                # Only `automation` is replaced -- the existing attack's own name casing is
+                # kept, mirroring the Action fix path (identity fields untouched on a fix).
+                by_lower_name[key]["automation"] = attack["automation"]
+                merge_info[attack["name"]] = "replaced"
+            else:
+                by_lower_name[key] = attack
+                merge_info[attack["name"]] = "added"
+
+        # Preserve existing attack order (updated in place), then append any genuinely new ones.
+        seen = set()
+        merged_attacks = []
+        for a in existing_attacks:
+            key = a["name"].lower()
+            merged_attacks.append(by_lower_name[key])
+            seen.add(key)
+        for attack in new_attacks:
+            key = attack["name"].lower()
+            if key not in seen:
+                merged_attacks.append(by_lower_name[key])
+                seen.add(key)
+
+        existing_data["attacks"] = merged_attacks
+        return json.dumps([existing_data], indent=2), merge_info
 
     async def setup_message(self, bot, channel=None):
         if channel is None:


### PR DESCRIPTION
### Summary
Extending the User Submitted Automations pipeline to differentiate actions/spell/monsters at source and propagate it to downstream so it can find the correct entity the automaiton belongs to

### Checklist
<!-- Put an "x" inside the braces to tick checkboxes, e.g. [x]. -->
#### PR Type
<!-- If the PR closes an issue, mention the issue at the top of the PR with "Resolves #X". -->
- [ ] This PR is a code change that implements a feature request.
- [ ] This PR fixes an issue.
- [ ] This PR adds a new feature that is not an open feature request.
- [ ] This PR is not a code change (e.g. documentation, README, ...)
#### Other
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
